### PR TITLE
Updates objective scores using upsert

### DIFF
--- a/src/app/(protected)/evaluation/components/evaluation-objective-input.tsx
+++ b/src/app/(protected)/evaluation/components/evaluation-objective-input.tsx
@@ -181,7 +181,7 @@ export function EvaluationObjectiveInput({ evaluationId, onSuccess, trigger }: E
 
             const { error } = await supabase
                 .from('objective_scores')
-                .insert(inserts)
+                .upsert(inserts, { onConflict: 'target_dormer_id,period_criteria_id' })
 
             if (error) throw error
 

--- a/src/app/evaluator/[evaluatorId]/page.tsx
+++ b/src/app/evaluator/[evaluatorId]/page.tsx
@@ -301,7 +301,7 @@ export default function EvaluatorPage() {
     }))
 
     try {
-      const { error } = await supabase.from("subjective_scores").insert(scoresToInsert)
+      const { error } = await supabase.from("subjective_scores").upsert(scoresToInsert, { onConflict: 'period_evaluator_id,target_dormer_id,period_criteria_id' })
 
       if (error) throw error
 


### PR DESCRIPTION
Modifies the objective and subjective score insertion logic to use `upsert` instead of `insert`.

This ensures that existing scores are updated instead of creating duplicate entries.

The `onConflict` option is used to specify the columns that should be used to determine if a row already exists.
